### PR TITLE
Set HOME environment variable

### DIFF
--- a/Dockerfile.jvm-alpine
+++ b/Dockerfile.jvm-alpine
@@ -3,8 +3,7 @@ FROM bellsoft/liberica-openjdk-alpine-musl:11.0.14
 ENV HOME=/home/modelfinder
 WORKDIR /home/modelfinder
 COPY modelfinder-server/target/modelfinder.jar modelfinder.jar
-RUN cd /home/modelfinder && \
-    chown -R 1001:0 /home/modelfinder && \
+RUN chown -R 1001:0 /home/modelfinder && \
     chmod -R g+rw /home/modelfinder && \
     ls -la
 

--- a/Dockerfile.jvm-alpine
+++ b/Dockerfile.jvm-alpine
@@ -6,7 +6,7 @@ COPY modelfinder-server/target/modelfinder.jar modelfinder.jar
 RUN cd /home/modelfinder && \
     chown -R 1001:0 /home/modelfinder && \
     chmod -R g+rw /home/modelfinder && \
-    ls -la /home/modelfinder
+    ls -la
 
 USER 1001
 EXPOSE 8080

--- a/Dockerfile.jvm-alpine
+++ b/Dockerfile.jvm-alpine
@@ -3,8 +3,8 @@ FROM bellsoft/liberica-openjdk-alpine-musl:11.0.14
 ENV HOME=/home/modelfinder
 WORKDIR $HOME
 COPY modelfinder-server/target/modelfinder.jar modelfinder.jar
-RUN chown -R 1001:0 $HOME && \
-    chmod -R g+rw $HOME && \
+RUN chown 1001:0 $HOME && \
+    chmod g+rw $HOME && \
     ls -la
 
 USER 1001

--- a/Dockerfile.jvm-alpine
+++ b/Dockerfile.jvm-alpine
@@ -1,5 +1,6 @@
 FROM bellsoft/liberica-openjdk-alpine-musl:11.0.14
 
+ENV HOME=/home/modelfinder
 WORKDIR /home/modelfinder
 COPY modelfinder-server/target/modelfinder.jar /home/modelfinder/modelfinder.jar
 RUN cd /home/modelfinder && \

--- a/Dockerfile.jvm-alpine
+++ b/Dockerfile.jvm-alpine
@@ -2,7 +2,7 @@ FROM bellsoft/liberica-openjdk-alpine-musl:11.0.14
 
 ENV HOME=/home/modelfinder
 WORKDIR /home/modelfinder
-COPY modelfinder-server/target/modelfinder.jar /home/modelfinder/modelfinder.jar
+COPY modelfinder-server/target/modelfinder.jar modelfinder.jar
 RUN cd /home/modelfinder && \
     chown -R 1001:0 /home/modelfinder && \
     chmod -R g+rw /home/modelfinder && \

--- a/Dockerfile.jvm-alpine
+++ b/Dockerfile.jvm-alpine
@@ -1,10 +1,10 @@
 FROM bellsoft/liberica-openjdk-alpine-musl:11.0.14
 
 ENV HOME=/home/modelfinder
-WORKDIR /home/modelfinder
+WORKDIR $HOME
 COPY modelfinder-server/target/modelfinder.jar modelfinder.jar
-RUN chown -R 1001:0 /home/modelfinder && \
-    chmod -R g+rw /home/modelfinder && \
+RUN chown -R 1001:0 $HOME && \
+    chmod -R g+rw $HOME && \
     ls -la
 
 USER 1001


### PR DESCRIPTION
Das Image läuft in OpenShift nicht, wegen dem Problem, das wir schon bei GRETL hatten. Das Erstellen des Index schlägt fehlt mit `java.lang.IllegalArgumentException: failed to create folder http://models.interlis.ch/`.

Hintergrund: OpenShift ergänzt in `/etc/passwd` automatisch folgenden Eintrag für den generischen User, unter welchem der Container läuft: `1000660000:x:1000660000:0:1000660000 user:/:/sbin/nologin`. Das heisst: Das Home-Verzeichnis des Users `1000660000` ist `/`. Java kriegt dann die Information, dass das `user.home` eben `/` ist, und die INTERLIS-Tools versuchen, `/.ilicache` anzulegen, was wegen den Berechtigungen nicht geht. (Und `$HOME` zeigt ebenfalls auf `/`.)

Lokal (`docker run ...`) funktioniert es, weil da in `/etc/passwd` kein Eintrag für den User 1001 steht. Obwohl auch in diesem Fall `$HOME` auf `/` zeigt, ist das Java `user.home` nicht gesetzt. (D.h. Java liest das wohl direkt aus `/etc/passwd`, nicht aus der `$HOME`-Variablen heraus.) Weil `user.home` nicht gesetzt ist, fallen die INTERLIS-Tool wohl auf das gegenwärtige Verzeichnis zurück, und das ist in diesem Fall `/home/modelfinder`, wo Schreibrechte bestehen.

Ich habe nun direkt im Dockerfile `HOME` gesetzt. Zudem habe ich an diversen Orten Überflüssiges entfernt oder Dinge vereinfacht, und dafür gesorgt, dass das Image 32MB kleiner wird.